### PR TITLE
fix: segmentation: adapt for new model output

### DIFF
--- a/cv_tensor_process/yolo_v8_process/README.md
+++ b/cv_tensor_process/yolo_v8_process/README.md
@@ -277,31 +277,23 @@ sudo apt install ros-jazzy-qrb-ros-yolo-process
 
 ```bash
 ## It is recommended to use python venv to avoid impacting the host environment
-mkdir venv_qaihub
-python -m venv venv_qaihub
+sudo apt install python3-venv
+python3 -m venv venv_qaihub
 source venv_qaihub/bin/activate
  
 ## install qai-hub related python packages
-pip install qai-hub==0.31.0
+pip3 install qai-hub
 
 ## configure qai-hub token, replace xxx with your own token got from qaihub page.
 qai-hub configure --api_token xxx
 
-pip install qai-hub-models[yolov8_det]==0.31.0
-pip install qai-hub-models[yolov8_seg]==0.31.0
+pip3 install "qai-hub-models[yolov8_det]"
+pip3 install "qai-hub-models[yolov8_seg]"
 ```
 
 
 
 ### 🔹Export model
-
-> For YOLOv8 segmentation model export, you may need to modify the tensor output shape as follows:
-```bash
-vim venv_qaihub/qaihub/lib/python3.12/site-packages/qai_hub_models/models/_shared/yolo/model.py
-
-## 1. Find "def get_channel_last_outputs()"
-## 2. Change "return ["protos"]" to "return [""]"
-```
 
 Supported target runtimes for different devices in the current ROS package are as follows.
 <table>

--- a/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/CMakeLists.txt
+++ b/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(qrb_yolo_process VERSION 1.0.1)
+project(qrb_yolo_process VERSION 1.0.2)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)

--- a/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/package.xml
+++ b/cv_tensor_process/yolo_v8_process/qrb_yolo_process_lib/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>qrb_yolo_process</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Library for Yolo pre/post process</description>
   <maintainer email="xiaolee@qti.qualcomm.com">Xiao Li</maintainer>
   <license>BSD-3-Clause-Clear</license>


### PR DESCRIPTION
- Update process logic accordingly for changes below:
  * tensor layout of mask_protos change from NCHW ([1,32,160,160]) to NHWC ([1,160,160,32]).
  * data type of class_idx changed from unit32[1,8400] to float32[1,8400].
  * update tensor name as per new QAIHUB model.