### PR TITLE
Fix stride alignment for RGB/BGR images with cropping

### DIFF
--- a/cv_tensor_process/cv_tensor_common_process/src/cv_tensor_common_process.cpp
+++ b/cv_tensor_process/cv_tensor_common_process/src/cv_tensor_common_process.cpp
@@ -144,9 +144,11 @@ void CvTensorCommonProcessNode::process_core(
 
   } else if (msg->encoding == "rgb8" || msg->encoding == "bgr8") {
     RCLCPP_DEBUG_STREAM(this->get_logger(), "color space convert skipped");
+    int aligned_width = qrb_ros::transport::image_utils::align_width(msg->width);
     cv::Mat img_rgb_tmp(
-        msg->height, msg->width, CV_8UC3, reinterpret_cast<uchar *>(img_data.get()));
-    image = img_rgb_tmp;
+        msg->height, aligned_width, CV_8UC3, reinterpret_cast<uchar *>(img_data.get()));
+    // crop to actual width to remove stride padding
+    image = img_rgb_tmp(cv::Rect(0, 0, msg->width, msg->height)).clone();
   } else {
     RCLCPP_ERROR_STREAM(this->get_logger(), "Unsupported input encoding: " << msg->encoding);
     throw std::invalid_argument("Unsupported input encoding: " + msg->encoding);


### PR DESCRIPTION
Motivation
The dmabuf buffer width is hardware-aligned, but the code used the raw msg->width to construct cv::Mat, causing row offset and garbled images for non-aligned resolutions.

Impact
Garbled image issue is fixed for all resolutions with non-aligned widths.
